### PR TITLE
Update previous base variation point containers and add a new one

### DIFF
--- a/src/helper/SourcePathToVariationPointsMap.ts
+++ b/src/helper/SourcePathToVariationPointsMap.ts
@@ -1,0 +1,6 @@
+import {AbstractVariationPointContainer} from "./variationContainer/AbstractVariationPointContainer";
+
+// TODO: add JS-Docs !!!
+export interface SourcePathToVariationPointsMap {
+    [sourcePath: string]: Array<AbstractVariationPointContainer>;
+}

--- a/src/helper/variationContainer/AbstractVariationPointContainer.ts
+++ b/src/helper/variationContainer/AbstractVariationPointContainer.ts
@@ -13,4 +13,6 @@ export interface AbstractVariationPointContainer {
 
     getVariationPointState(): Boolean;
 
+    addToInternalVariationPoint(variationPoint: AbstractVariationPointContainer);
+
 }

--- a/src/helper/variationContainer/AbstractVariationPointContainer.ts
+++ b/src/helper/variationContainer/AbstractVariationPointContainer.ts
@@ -1,7 +1,5 @@
-import {TypeScriptVariation} from "./typescript/TypeScriptVariation";
-
 export interface AbstractVariationPointContainer {
-    getInternalVariationPoints(): Array<TypeScriptVariation>;
+    getInternalVariationPoints(): Array<AbstractVariationPointContainer>;
 
     getVariationExpression(): String;
 

--- a/src/helper/variationContainer/typescript/implementation/BlockVariationPoint.ts
+++ b/src/helper/variationContainer/typescript/implementation/BlockVariationPoint.ts
@@ -1,0 +1,71 @@
+import {AbstractVariationPointContainer} from "../../AbstractVariationPointContainer";
+import {Block, Node, SourceFile, ts} from "ts-simple-ast";
+import {CommentRange} from 'typescript';
+import {isUndefined} from "util";
+
+
+export class BlockVariationPoint implements AbstractVariationPointContainer {
+    private sourceFile: SourceFile;
+    private block: Node;
+    private variabilityExp: String = null;
+    private isIncludedInSource: Boolean = true;
+    private internalVariationPoints: Array<AbstractVariationPointContainer>;
+
+    constructor(sourceFile: SourceFile, node: Node<ts.Block>) {
+        this.sourceFile = sourceFile;
+        this.block = node as Block;
+        this.internalVariationPoints = [];
+
+        this.extractVariationExpression();
+    }
+
+    applyVariation(): boolean {
+        return false;
+    }
+
+    getInternalVariationPoints(): Array<AbstractVariationPointContainer> {
+        return undefined;
+    }
+
+    getVariationExpression(): String {
+        return "";
+    }
+
+    getVariationPointState(): Boolean {
+        return false;
+    }
+
+    printInfo(): String {
+        return "";
+    }
+
+    setVariationPointState(status: Boolean) {
+    }
+
+    variationExpressionContains(conditionExpression: String): boolean {
+        return false;
+    }
+
+    private extractVariationExpression(): String {
+        let commentsRange: CommentRange[] = ts.getLeadingCommentRanges(this.block.getSourceFile().getText(), this.block.getFullStart());
+
+        if (isUndefined(commentsRange)) {
+            return null;
+        }
+
+        for (let i = 0; i < commentsRange.length; i++) {
+            let comment = this.sourceFile.getText().slice(commentsRange[i].pos, commentsRange[i].end);
+            if (comment.indexOf('@presence') >= 0) {
+                this.variabilityExp = comment;
+                return comment;
+            }
+        }
+
+        return null;
+    }
+
+    addToInternalVariationPoint(variationPoint: AbstractVariationPointContainer) {
+        this.internalVariationPoints.push(variationPoint);
+    }
+
+}

--- a/src/helper/variationContainer/typescript/implementation/ClassVariationPoint.ts
+++ b/src/helper/variationContainer/typescript/implementation/ClassVariationPoint.ts
@@ -1,17 +1,18 @@
-import {TypeScriptVariation} from "../TypeScriptVariation";
 import {ClassDeclaration, JSDoc, Node, SourceFile, ts} from "ts-simple-ast";
 import {DocCommentAnalyzer} from "../../../../main/typeScriptAnalyzers/DocCommentAnalyzer";
+import {AbstractVariationPointContainer} from "../../AbstractVariationPointContainer";
 
 
-export class ClassVariationPoint implements TypeScriptVariation {
+export class ClassVariationPoint implements AbstractVariationPointContainer {
 
     private sourceFile: SourceFile;
     private classDec: ClassDeclaration;
     private variabilityExp: String = null;
+    private isIncludedInSource: Boolean = true;
     private readonly jsDocs: JSDoc[];
     private readonly className: String;
 
-    private internalVariationPoints: TypeScriptVariation[];
+    private internalVariationPoints: Array<AbstractVariationPointContainer>;
 
     constructor(sourceFile: SourceFile, node: Node<ts.ClassDeclaration>) {
         this.sourceFile = sourceFile;
@@ -19,7 +20,7 @@ export class ClassVariationPoint implements TypeScriptVariation {
         this.jsDocs = this.classDec.getJsDocs();
         this.className = this.classDec.getName();
 
-        this.internalVariationPoints = new Array<TypeScriptVariation>();
+        this.internalVariationPoints = new Array<AbstractVariationPointContainer>();
 
         this.extractVariationExpression();
     }
@@ -66,8 +67,16 @@ export class ClassVariationPoint implements TypeScriptVariation {
         return this.className;
     }
 
-    public getInternalVariationPoints(): Array<TypeScriptVariation> {
+    public getInternalVariationPoints(): Array<AbstractVariationPointContainer> {
         return this.internalVariationPoints;
+    }
+
+    setVariationPointState(status: Boolean) {
+        this.isIncludedInSource = true;
+    }
+
+    getVariationPointState(): Boolean {
+        return this.isIncludedInSource;
     }
 
 

--- a/src/helper/variationContainer/typescript/implementation/ClassVariationPoint.ts
+++ b/src/helper/variationContainer/typescript/implementation/ClassVariationPoint.ts
@@ -20,19 +20,9 @@ export class ClassVariationPoint implements AbstractVariationPointContainer {
         this.jsDocs = this.classDec.getJsDocs();
         this.className = this.classDec.getName();
 
-        this.internalVariationPoints = new Array<AbstractVariationPointContainer>();
+        this.internalVariationPoints = [];
 
         this.extractVariationExpression();
-    }
-
-    private extractVariationExpression() {
-        for (let j = 0; j < this.jsDocs.length; j++) {
-            let variabilityExp = DocCommentAnalyzer.extractVariabilityExpression(this.jsDocs[j]);
-            if (variabilityExp != null) {
-                this.variabilityExp = variabilityExp;
-                return variabilityExp;
-            }
-        }
     }
 
     getVariationExpression(): String {
@@ -59,10 +49,6 @@ export class ClassVariationPoint implements AbstractVariationPointContainer {
         return false;
     }
 
-    private removeClassFromSource(): boolean {
-        return false;
-    }
-
     public getClassName(): String {
         return this.className;
     }
@@ -77,6 +63,24 @@ export class ClassVariationPoint implements AbstractVariationPointContainer {
 
     getVariationPointState(): Boolean {
         return this.isIncludedInSource;
+    }
+
+    private extractVariationExpression() {
+        for (let j = 0; j < this.jsDocs.length; j++) {
+            let variabilityExp = DocCommentAnalyzer.extractVariabilityExpression(this.jsDocs[j]);
+            if (variabilityExp != null) {
+                this.variabilityExp = variabilityExp;
+                return variabilityExp;
+            }
+        }
+    }
+
+    private removeClassFromSource(): boolean {
+        return false;
+    }
+
+    addToInternalVariationPoint(variationPoint: AbstractVariationPointContainer) {
+        this.internalVariationPoints.push(variationPoint);
     }
 
 

--- a/src/helper/variationContainer/typescript/implementation/MethodVariationPoint.ts
+++ b/src/helper/variationContainer/typescript/implementation/MethodVariationPoint.ts
@@ -22,21 +22,10 @@ export class MethodVariationPoint implements AbstractVariationPointContainer {
         this.methodName = this.methodDec.getName();
         this.parameters = this.methodDec.getParameters();
 
-        this.internalVariationPoints = new Array<AbstractVariationPointContainer>();
+        this.internalVariationPoints = [];
 
         this.extractVariationExpression();
     }
-
-    private extractVariationExpression() {
-        for (let j = 0; j < this.jsDocs.length; j++) {
-            let variabilityExp = DocCommentAnalyzer.extractVariabilityExpression(this.jsDocs[j]);
-            if (variabilityExp != null) {
-                this.variabilityExp = variabilityExp;
-                return variabilityExp;
-            }
-        }
-    }
-
 
     getVariationExpression(): String {
         if (this.variabilityExp != null) {
@@ -62,17 +51,12 @@ export class MethodVariationPoint implements AbstractVariationPointContainer {
         return false;
     }
 
-    getClassName(): String {
+    getMethodName(): String {
         return this.methodName;
     }
 
     getInternalVariationPoints(): Array<AbstractVariationPointContainer> {
         return this.internalVariationPoints;
-    }
-
-    private removeMethodFromSource(): Boolean {
-        // TODO:
-        return false;
     }
 
     getVariationPointState(): Boolean {
@@ -81,6 +65,25 @@ export class MethodVariationPoint implements AbstractVariationPointContainer {
 
     setVariationPointState(status: Boolean) {
         this.isIncludedInSource = status;
+    }
+
+    private extractVariationExpression() {
+        for (let j = 0; j < this.jsDocs.length; j++) {
+            let variabilityExp = DocCommentAnalyzer.extractVariabilityExpression(this.jsDocs[j]);
+            if (variabilityExp != null) {
+                this.variabilityExp = variabilityExp;
+                return variabilityExp;
+            }
+        }
+    }
+
+    private removeMethodFromSource(): Boolean {
+        // TODO:
+        return false;
+    }
+
+    addToInternalVariationPoint(variationPoint: AbstractVariationPointContainer) {
+        this.internalVariationPoints.push(variationPoint);
     }
 
 }

--- a/src/helper/variationContainer/typescript/implementation/MethodVariationPoint.ts
+++ b/src/helper/variationContainer/typescript/implementation/MethodVariationPoint.ts
@@ -1,18 +1,19 @@
-import {TypeScriptVariation} from "../TypeScriptVariation";
 import {JSDoc, MethodDeclaration, Node, ParameterDeclaration, SourceFile, ts} from "ts-simple-ast";
 import {DocCommentAnalyzer} from "../../../../main/typeScriptAnalyzers/DocCommentAnalyzer";
+import {AbstractVariationPointContainer} from "../../AbstractVariationPointContainer";
 
 
-export class MethodVariationPoint implements TypeScriptVariation {
+export class MethodVariationPoint implements AbstractVariationPointContainer {
 
     private sourceFile: SourceFile;
     private methodDec: MethodDeclaration;
     private variabilityExp: String = null;
+    private isIncludedInSource: Boolean = true;
     private readonly jsDocs: Array<JSDoc>;
     private readonly methodName: String;
     private readonly parameters: Array<ParameterDeclaration>;
 
-    private internalVariationPoints: Array<TypeScriptVariation>;
+    private internalVariationPoints: Array<AbstractVariationPointContainer>;
 
     constructor(sourceFile: SourceFile, node: Node<ts.MethodDeclaration>) {
         this.sourceFile = sourceFile;
@@ -21,7 +22,7 @@ export class MethodVariationPoint implements TypeScriptVariation {
         this.methodName = this.methodDec.getName();
         this.parameters = this.methodDec.getParameters();
 
-        this.internalVariationPoints = new Array<TypeScriptVariation>();
+        this.internalVariationPoints = new Array<AbstractVariationPointContainer>();
 
         this.extractVariationExpression();
     }
@@ -65,13 +66,21 @@ export class MethodVariationPoint implements TypeScriptVariation {
         return this.methodName;
     }
 
-    getInternalVariationPoints(): Array<TypeScriptVariation> {
+    getInternalVariationPoints(): Array<AbstractVariationPointContainer> {
         return this.internalVariationPoints;
     }
 
     private removeMethodFromSource(): Boolean {
         // TODO:
         return false;
+    }
+
+    getVariationPointState(): Boolean {
+        return this.isIncludedInSource;
+    }
+
+    setVariationPointState(status: Boolean) {
+        this.isIncludedInSource = status;
     }
 
 }


### PR DESCRIPTION
- Update `AbstractVariationPoint` interface methods signature.
- Add a new method to the `AbstractVariationPoint` interface.
- Add `BlockVariationPoint` class to wrap the variation points defined inside methods.
- Add a helper `interface` which maps the path of a source file to its variation points collection
- Apply minor bug fixes
